### PR TITLE
[CI] Vitepress `lastUpdated` Not Displaying

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       run: pnpm i
     - name: Build
       run: |
+        git config --global --add safe.directory '*'
         pnpm build
         touch .vitepress/dist/.nojekyll
     - name: Upload Page Artifact


### PR DESCRIPTION
It works locally, but somehow broken on Github. The built artifact on CI doesn't generate date info. Need to tweak CI for more debug info.